### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/MatuMatma/2ab23a7e-b357-4e4a-a284-e0d3ca9104ab/4f8a27d9-d428-4ec1-b5e5-9c2dcda1ec89/_apis/work/boardbadge/02e69382-7a94-43aa-8ee8-839d7f1995ef)](https://dev.azure.com/MatuMatma/2ab23a7e-b357-4e4a-a284-e0d3ca9104ab/_boards/board/t/4f8a27d9-d428-4ec1-b5e5-9c2dcda1ec89/Microsoft.RequirementCategory)
 # MatuMatma


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#5](https://dev.azure.com/MatuMatma/2ab23a7e-b357-4e4a-a284-e0d3ca9104ab/_workitems/edit/5). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.